### PR TITLE
fix: don't download comics we know we can't

### DIFF
--- a/bin/index.js
+++ b/bin/index.js
@@ -24,11 +24,16 @@ const argv = yargs
   .argv
 
 async function write ({ data, img }, dir, latest) {
+  const hasImage = img !== null
+
   try {
     await fs.outputJSON(join(dir, 'info.json'), data, { spaces: '\t' })
-    await fs.outputFile(join(dir, basename(data.img)), img)
-    await fs.outputFile(join(dir, `image${extname(data.img)}`), img)
-    await fs.outputFile(join(dir, 'index.html'), comicPage(data, latest))
+    await fs.outputFile(join(dir, 'index.html'), comicPage(data, latest, hasImage))
+
+    if (hasImage) {
+      await fs.outputFile(join(dir, basename(data.img)), img)
+      await fs.outputFile(join(dir, `image${extname(data.img)}`), img)
+    }
   } catch (err) {
     await fs.remove(dir)
     throw err
@@ -114,6 +119,8 @@ async function run () {
   }
 
   added = added.sort((a, b) => a.num - b.num)
+  await fs.remove(join(argv.dir, 'latest'))
+  await fs.copy(join(argv.dir, latest.toString()), join(argv.dir, 'latest'))
   await fs.copyFile(join(__dirname, '../node_modules/tachyons/css/tachyons.min.css'), join(argv.dir, 'tachyons.css'))
   await fs.copyFile(join(__dirname, '../node_modules/tachyons-columns/css/tachyons-columns.min.css'), join(argv.dir, 'tachyons-columns.css'))
   await fs.outputFile(join(argv.dir, 'index.html'), homePage(added))

--- a/lib/html.js
+++ b/lib/html.js
@@ -9,9 +9,7 @@ const classes = {
   btn: 'dib navy mh2 pa2 bg-light-blue hover-bg-lightest-blue br2 ba bw1 b--navy no-underline'
 }
 
-const comicPage = ({ alt, title, transcript, num, img }, latest) => {
-
-  return `<html>
+const comicPage = ({ alt, title, transcript, num, img }, latest) => `<html>
 <head>
   <title>${num} - ${title}</title>
   <meta charset=utf-8>
@@ -33,7 +31,6 @@ const comicPage = ({ alt, title, transcript, num, img }, latest) => {
   ${credits}
 </body>
 </html>`
-}
 
 const homePage = (list) => `<html>
 <head>

--- a/lib/xkcd.js
+++ b/lib/xkcd.js
@@ -26,7 +26,13 @@ async function getImage (url) {
 async function getComic (id) {
   const raw = await fetch(`https://xkcd.com/${id}/info.0.json`)
   const data = await raw.json()
-  const img = await getImage(data.img)
+  let img = null
+
+  // Some comics, such as 1608 and 1663, are composed by interactive
+  // games and cannot be downloaded as images, so we just ignore them.
+  if (data.img !== 'https://imgs.xkcd.com/comics/') {
+    img = await getImage(data.img)
+  }
 
   return { data, img }
 }


### PR DESCRIPTION
#6 introduced error checking for image downloads. With that, some of the comics we were downloading failed because they are not actually images. This way, we only try to download what we know that can be downloaded.

License: MIT
Signed-off-by: Henrique Dias <hacdias@gmail.com>